### PR TITLE
adding cookie support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,204 @@
 # go-flaresolverr
 
 Go client for https://github.com/FlareSolverr/FlareSolverr
+
+## Features
+
+- HTTP GET and POST requests through FlareSolverr proxy
+- Session management (create, list, destroy) for persistent browser instances
+- Cookie support for authenticated requests
+- Proxy support for routing requests
+- Context-aware with configurable timeouts
+- Type-safe interface with proper error handling
+- Full test coverage
+
+## Installation
+
+```bash
+go get github.com/SkYNewZ/go-flaresolverr
+```
+
+## Usage
+
+### Basic GET Request
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "time"
+
+    "github.com/SkYNewZ/go-flaresolverr"
+    "github.com/google/uuid"
+)
+
+func main() {
+    // Create a new FlareSolverr client
+    client := flaresolverr.New("http://127.0.0.1:8191/v1", 60*time.Second, nil)
+
+    // Make a simple GET request
+    resp, err := client.Get(
+        context.Background(),
+        "https://example.com",
+        uuid.Nil, // no session
+        nil,      // no cookies
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println("Status:", resp.Status)
+    fmt.Println("Response:", resp.Solution.Response)
+}
+```
+
+### Using Sessions
+
+Sessions allow you to maintain browser state across multiple requests without re-solving challenges.
+
+```go
+// Create a new session
+sessionID := uuid.New()
+_, err := client.CreateSession(context.Background(), sessionID)
+if err != nil {
+    log.Fatal(err)
+}
+defer client.DestroySession(context.Background(), sessionID)
+
+// Use the session for multiple requests
+resp1, err := client.Get(context.Background(), "https://example.com", sessionID, nil)
+if err != nil {
+    log.Fatal(err)
+}
+
+resp2, err := client.Get(context.Background(), "https://example.com/page2", sessionID, nil)
+if err != nil {
+    log.Fatal(err)
+}
+
+// List all active sessions
+sessions, err := client.ListSessions(context.Background())
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Active sessions:", sessions.Sessions)
+```
+
+### Using Cookies
+
+Send custom cookies with your requests:
+
+```go
+cookies := []*flaresolverr.Cookie{
+    {Name: "session_id", Value: "abc123"},
+    {Name: "auth_token", Value: "xyz789"},
+}
+
+resp, err := client.Get(
+    context.Background(),
+    "https://example.com/protected",
+    uuid.Nil, // no session
+    cookies,  // with cookies
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Println("Response with cookies:", resp.Status)
+```
+
+### POST Requests
+
+```go
+// POST request with form data
+postData := "username=john&password=secret"
+
+resp, err := client.Post(
+    context.Background(),
+    "https://example.com/login",
+    uuid.Nil,  // no session
+    postData,  // application/x-www-form-urlencoded
+    nil,       // no cookies
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Println("POST response:", resp.Status)
+```
+
+### Using a Proxy
+
+```go
+// GET request through a proxy
+resp, err := client.Get(
+    context.Background(),
+    "https://example.com",
+    uuid.Nil,                          // no session
+    nil,                               // no cookies
+    "http://proxy.example.com:8080",   // proxy URL
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Println("Response via proxy:", resp.Status)
+```
+
+### Complete Example with Session, Cookies, and Proxy
+
+```go
+// Create session
+sessionID := uuid.New()
+_, err := client.CreateSession(context.Background(), sessionID)
+if err != nil {
+    log.Fatal(err)
+}
+defer client.DestroySession(context.Background(), sessionID)
+
+// Prepare cookies
+cookies := []*flaresolverr.Cookie{
+    {Name: "preferences", Value: "dark_mode"},
+}
+
+// POST with session, cookies, and proxy
+resp, err := client.Post(
+    context.Background(),
+    "https://example.com/api",
+    sessionID,                         // with session
+    "action=submit&data=value",        // POST data
+    cookies,                           // with cookies
+    "http://proxy.example.com:8080",   // with proxy
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Println("Complete example:", resp.Status)
+fmt.Println("User Agent:", resp.Solution.UserAgent)
+fmt.Println("Response cookies:", resp.Solution.Cookies)
+```
+
+## Error Handling
+
+The library provides typed errors for common scenarios:
+
+```go
+resp, err := client.Get(context.Background(), "https://example.com", uuid.Nil, nil)
+if err != nil {
+    if errors.Is(err, flaresolverr.ErrRequestTimeout) {
+        log.Println("Request timed out")
+    } else if errors.Is(err, flaresolverr.ErrUnexpectedError) {
+        log.Println("Unexpected error from FlareSolverr")
+    } else {
+        log.Fatal(err)
+    }
+}
+```
+
+## License
+
+GPL-3.0

--- a/client.gen.go
+++ b/client.gen.go
@@ -28,9 +28,10 @@ type Client interface {
 	// When you no longer need to use a session you should make sure to close it.
 	DestroySession(ctx context.Context, session uuid.UUID) error
 	// Get makes an HTTP GET request using flaresolverr proxy
-	// Session can be nil.
-	Get(ctx context.Context, u string, session uuid.UUID, proxy ...string) (*Response, error)
+	// Session and Cookies can be nil.
+	Get(ctx context.Context, u string, session uuid.UUID, cookies []*Cookie, proxy ...string) (*Response, error)
 	// Post makes an HTTP POST request using flaresolverr proxy
 	// data must be an application/x-www-form-urlencoded string.
-	Post(ctx context.Context, u string, session uuid.UUID, data string, proxy ...string) (*Response, error)
+	// Session and Cookies can be nil.
+	Post(ctx context.Context, u string, session uuid.UUID, data string, cookies []*Cookie, proxy ...string) (*Response, error)
 }

--- a/client.gen.go
+++ b/client.gen.go
@@ -28,10 +28,10 @@ type Client interface {
 	// When you no longer need to use a session you should make sure to close it.
 	DestroySession(ctx context.Context, session uuid.UUID) error
 	// Get makes an HTTP GET request using flaresolverr proxy
-	// Session can be uuid.Nil. Cookies can be nil, empty, or omitted.
+	// Session can be uuid.Nil. Cookies can be nil or empty.
 	Get(ctx context.Context, u string, session uuid.UUID, cookies []*Cookie, proxy ...string) (*Response, error)
 	// Post makes an HTTP POST request using flaresolverr proxy
 	// data must be an application/x-www-form-urlencoded string.
-	// Session can be uuid.Nil. Cookies can be nil, empty, or omitted.
+	// Session can be uuid.Nil. Cookies can be nil or empty.
 	Post(ctx context.Context, u string, session uuid.UUID, data string, cookies []*Cookie, proxy ...string) (*Response, error)
 }

--- a/client.gen.go
+++ b/client.gen.go
@@ -28,10 +28,10 @@ type Client interface {
 	// When you no longer need to use a session you should make sure to close it.
 	DestroySession(ctx context.Context, session uuid.UUID) error
 	// Get makes an HTTP GET request using flaresolverr proxy
-	// Session and Cookies can be nil.
+	// Session can be uuid.Nil. Cookies can be nil, empty, or omitted.
 	Get(ctx context.Context, u string, session uuid.UUID, cookies []*Cookie, proxy ...string) (*Response, error)
 	// Post makes an HTTP POST request using flaresolverr proxy
 	// data must be an application/x-www-form-urlencoded string.
-	// Session and Cookies can be nil.
+	// Session can be uuid.Nil. Cookies can be nil, empty, or omitted.
 	Post(ctx context.Context, u string, session uuid.UUID, data string, cookies []*Cookie, proxy ...string) (*Response, error)
 }

--- a/client.go
+++ b/client.go
@@ -154,7 +154,7 @@ func (c *client) DestroySession(ctx context.Context, session uuid.UUID) error {
 }
 
 // Get makes an HTTP GET request using flaresolverr proxy
-// Session can be uuid.Nil. Cookies can be nil, empty, or omitted.
+// Session can be uuid.Nil. Cookies can be nil or empty.
 func (c *client) Get(ctx context.Context, u string, session uuid.UUID, cookies []*Cookie, proxy ...string) (*Response, error) {
 	cmd := &flaresolverrCommand{
 		Cmd:               CommandRequestget,
@@ -173,7 +173,7 @@ func (c *client) Get(ctx context.Context, u string, session uuid.UUID, cookies [
 
 // Post makes an HTTP POST request using flaresolverr proxy
 // data must be an application/x-www-form-urlencoded string.
-// Session can be uuid.Nil. Cookies can be nil, empty, or omitted.
+// Session can be uuid.Nil. Cookies can be nil or empty.
 func (c *client) Post(ctx context.Context, u string, session uuid.UUID, data string, cookies []*Cookie, proxy ...string) (*Response, error) {
 	cmd := &flaresolverrCommand{
 		Cmd:               CommandRequestpost,

--- a/client.go
+++ b/client.go
@@ -154,7 +154,7 @@ func (c *client) DestroySession(ctx context.Context, session uuid.UUID) error {
 }
 
 // Get makes an HTTP GET request using flaresolverr proxy
-// Session and Cookies can be nil.
+// Session can be uuid.Nil. Cookies can be nil, empty, or omitted.
 func (c *client) Get(ctx context.Context, u string, session uuid.UUID, cookies []*Cookie, proxy ...string) (*Response, error) {
 	cmd := &flaresolverrCommand{
 		Cmd:               CommandRequestget,
@@ -173,7 +173,7 @@ func (c *client) Get(ctx context.Context, u string, session uuid.UUID, cookies [
 
 // Post makes an HTTP POST request using flaresolverr proxy
 // data must be an application/x-www-form-urlencoded string.
-// Session and Cookies can be nil.
+// Session can be uuid.Nil. Cookies can be nil, empty, or omitted.
 func (c *client) Post(ctx context.Context, u string, session uuid.UUID, data string, cookies []*Cookie, proxy ...string) (*Response, error) {
 	cmd := &flaresolverrCommand{
 		Cmd:               CommandRequestpost,

--- a/client.go
+++ b/client.go
@@ -44,6 +44,26 @@ func New(baseURL string, timeout time.Duration, httpClient *http.Client) Client 
 	return &client{baseURL: baseURL, httpClient: httpClient, timeout: timeout}
 }
 
+// Cookie represents a browser cookie to be sent with requests.
+type Cookie struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// ResponseCookie represents a cookie returned in the response from FlareSolverr.
+type ResponseCookie struct {
+	Name     string  `json:"name"`
+	Value    string  `json:"value"`
+	Domain   string  `json:"domain"`
+	Path     string  `json:"path"`
+	Expires  float64 `json:"expires"`
+	Size     int     `json:"size"`
+	HTTPOnly bool    `json:"httpOnly"`
+	Secure   bool    `json:"secure"`
+	Session  bool    `json:"session"`
+	SameSite string  `json:"sameSite,omitempty"`
+}
+
 type Response struct {
 	Status         string            `json:"status"`
 	Message        string            `json:"message"`
@@ -76,31 +96,20 @@ type ResponseSolution struct {
 		ContentEncoding     string `json:"content-encoding"`
 		AltSvc              string `json:"alt-svc"`
 	} `json:"headers"`
-	Response string `json:"response"`
-	Cookies  []struct {
-		Name     string  `json:"name"`
-		Value    string  `json:"value"`
-		Domain   string  `json:"domain"`
-		Path     string  `json:"path"`
-		Expires  float64 `json:"expires"`
-		Size     int     `json:"size"`
-		HTTPOnly bool    `json:"httpOnly"`
-		Secure   bool    `json:"secure"`
-		Session  bool    `json:"session"`
-		SameSite string  `json:"sameSite,omitempty"`
-	} `json:"cookies"`
-	UserAgent string `json:"userAgent"`
+	Response  string            `json:"response"`
+	Cookies   []*ResponseCookie `json:"cookies"`
+	UserAgent string            `json:"userAgent"`
 }
 
 type flaresolverrCommand struct {
-	Cmd               command `json:"cmd"`
-	URL               string  `json:"url"`
-	Session           string  `json:"session,omitempty"`
-	MaxTimeout        int     `json:"maxTimeout"`
-	Cookies           []any   `json:"cookies,omitempty"`
-	ReturnOnlyCookies bool    `json:"returnOnlyCookies,omitempty"`
-	Proxy             string  `json:"proxy,omitempty"`
-	PostData          string  `json:"postData,omitempty"`
+	Cmd               command   `json:"cmd"`
+	URL               string    `json:"url"`
+	Session           string    `json:"session,omitempty"`
+	MaxTimeout        int       `json:"maxTimeout"`
+	Cookies           []*Cookie `json:"cookies,omitempty"`
+	ReturnOnlyCookies bool      `json:"returnOnlyCookies,omitempty"`
+	Proxy             string    `json:"proxy,omitempty"`
+	PostData          string    `json:"postData,omitempty"`
 }
 
 // CreateSession launch a new browser instance
@@ -145,13 +154,13 @@ func (c *client) DestroySession(ctx context.Context, session uuid.UUID) error {
 }
 
 // Get makes an HTTP GET request using flaresolverr proxy
-// Session can be nil.
-func (c *client) Get(ctx context.Context, u string, session uuid.UUID, proxy ...string) (*Response, error) {
+// Session and Cookies can be nil.
+func (c *client) Get(ctx context.Context, u string, session uuid.UUID, cookies []*Cookie, proxy ...string) (*Response, error) {
 	cmd := &flaresolverrCommand{
 		Cmd:               CommandRequestget,
 		URL:               u,
 		Session:           handleSession(session),
-		Cookies:           nil, // TODO: handle cookies
+		Cookies:           cookies,
 		ReturnOnlyCookies: false,
 	}
 
@@ -164,12 +173,13 @@ func (c *client) Get(ctx context.Context, u string, session uuid.UUID, proxy ...
 
 // Post makes an HTTP POST request using flaresolverr proxy
 // data must be an application/x-www-form-urlencoded string.
-func (c *client) Post(ctx context.Context, u string, session uuid.UUID, data string, proxy ...string) (*Response, error) {
+// Session and Cookies can be nil.
+func (c *client) Post(ctx context.Context, u string, session uuid.UUID, data string, cookies []*Cookie, proxy ...string) (*Response, error) {
 	cmd := &flaresolverrCommand{
 		Cmd:               CommandRequestpost,
 		URL:               u,
 		Session:           handleSession(session),
-		Cookies:           nil, // TODO: handle cookies
+		Cookies:           cookies,
 		ReturnOnlyCookies: false,
 		PostData:          data,
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -252,6 +252,22 @@ func Test_client_Get(t *testing.T) {
 			)); diff != "" {
 				t.Errorf("Get() mismatch (-want +got):\n%s", diff)
 			}
+
+			// Additional validation for cookie test case
+			if tt.name == "Expect a response with cookies" {
+				// Verify response contains cookies (httpbin.org/cookies echoes back cookies in response body)
+				if got.Solution.Response == "" {
+					t.Error("Expected response body to contain cookie data, got empty response")
+				}
+				// Verify that cookies were returned by the server
+				if got.Solution.Cookies == nil {
+					t.Error("Expected Solution.Cookies to be populated, got nil")
+				}
+				// Validate that we actually sent cookies and they were returned
+				if len(got.Solution.Cookies) < 2 {
+					t.Errorf("Expected at least 2 cookies to be sent and returned, got %d", len(got.Solution.Cookies))
+				}
+			}
 		})
 	}
 }
@@ -402,6 +418,22 @@ func Test_client_Post(t *testing.T) {
 				"Solution.Response",
 			)); diff != "" {
 				t.Errorf("Post() mismatch (-want +got):\n%s", diff)
+			}
+
+			// Additional validation for cookie test case
+			if tt.name == "Expect a response with cookies" {
+				// Verify response contains data (httpbin.org/anything echoes back request details)
+				if got.Solution.Response == "" {
+					t.Error("Expected response body to contain request data, got empty response")
+				}
+				// Verify that cookies were returned by the server
+				if got.Solution.Cookies == nil {
+					t.Error("Expected Solution.Cookies to be populated, got nil")
+				}
+				// Validate that we actually sent cookies and they were returned
+				if len(got.Solution.Cookies) < 2 {
+					t.Errorf("Expected at least 2 cookies to be sent and returned, got %d", len(got.Solution.Cookies))
+				}
 			}
 		})
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -182,6 +182,7 @@ func Test_client_Get(t *testing.T) {
 		ctx     context.Context
 		u       string
 		session uuid.UUID
+		cookies []*Cookie
 		proxy   []string
 	}
 	tests := []struct {
@@ -196,6 +197,7 @@ func Test_client_Get(t *testing.T) {
 				ctx:     context.Background(),
 				u:       "https://httpbin.org/status/200",
 				session: uuid.Nil,
+				cookies: nil,
 				proxy:   nil,
 			},
 			want: &Response{
@@ -208,10 +210,32 @@ func Test_client_Get(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Expect a response with cookies",
+			args: args{
+				ctx:     context.Background(),
+				u:       "https://httpbin.org/cookies",
+				session: uuid.Nil,
+				cookies: []*Cookie{
+					{Name: "test_cookie", Value: "test_value"},
+					{Name: "session_id", Value: "abc123"},
+				},
+				proxy: nil,
+			},
+			want: &Response{
+				Status:  "ok",
+				Message: "Challenge not detected!",
+				Solution: &ResponseSolution{
+					URL:    "https://httpbin.org/cookies",
+					Status: http.StatusOK,
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.Get(tt.args.ctx, tt.args.u, tt.args.session, tt.args.proxy...)
+			got, err := c.Get(tt.args.ctx, tt.args.u, tt.args.session, tt.args.cookies, tt.args.proxy...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -306,6 +330,7 @@ func Test_client_Post(t *testing.T) {
 		u       string
 		session uuid.UUID
 		data    string
+		cookies []*Cookie
 		proxy   []string
 	}
 	tests := []struct {
@@ -321,6 +346,7 @@ func Test_client_Post(t *testing.T) {
 				u:       "https://httpbin.org/anything",
 				session: uuid.Nil,
 				data:    "foo=bar",
+				cookies: nil,
 				proxy:   nil,
 			},
 			want: &Response{
@@ -334,10 +360,33 @@ func Test_client_Post(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Expect a response with cookies",
+			args: args{
+				ctx:     context.Background(),
+				u:       "https://httpbin.org/anything",
+				session: uuid.Nil,
+				data:    "foo=bar",
+				cookies: []*Cookie{
+					{Name: "auth_token", Value: "xyz789"},
+					{Name: "user_pref", Value: "dark_mode"},
+				},
+				proxy: nil,
+			},
+			want: &Response{
+				Status:  "ok",
+				Message: "Challenge not detected!",
+				Solution: &ResponseSolution{
+					URL:    "https://httpbin.org/anything",
+					Status: http.StatusOK,
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.Post(tt.args.ctx, tt.args.u, tt.args.session, tt.args.data, tt.args.proxy...)
+			got, err := c.Post(tt.args.ctx, tt.args.u, tt.args.session, tt.args.data, tt.args.cookies, tt.args.proxy...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Post() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Yo! thanks for making this, I found it when looking for session support! 

I'm adding cookie support to HTTP request methods 🚀

This PR adds the ability to send custom cookies with GET and POST requests

Changes:

  - Introduced `Cookie` type with `Name` and `Value` fields for request cookies
  - Introduced `ResponseCookie` type with full metadata for cookies returned from FlareSolverr
  - Updated `Get()` and `Post()` method signatures to accept optional `[]*Cookie` parameter
  - Changed `flaresolverrCommand.Cookies` field from `[]any` to `[]*Cookie` for type safety
  - Removed `TODO` comments for cookie handling - feature is now fully implemented
  - Updated generated Client interface via `go generate` to reflect new method signatures
  - Updated `README.md` with comprehensive features section and usage examples

  Testing:

  - Added integration tests for `GET` and `POST` requests with cookies using httpbin endpoints
  - Enhanced tests validate response body population, cookie return, and actual cookie processing
  - All existing tests updated to pass nil for cookies parameter
  - All tests passing ✓

  Breaking Change ⚠️:

  This is a breaking change as it modifies the `Get()` and `Post()` method signatures by adding a new cookies `[]*Cookie` parameter between the session and proxy parameters.


Before:
```go
Get(ctx context.Context, u string, session uuid.UUID, proxy ...string) (*Response, error)
Post(ctx context.Context, u string, session uuid.UUID, data string, proxy ...string) (*Response, error)
```
After:
```go
Get(ctx context.Context, u string, session uuid.UUID, cookies []*Cookie, proxy ...string) (*Response, error)
Post(ctx context.Context, u string, session uuid.UUID, data string, cookies []*Cookie, proxy ...string) (*Response, error)
```

Migration guide: Pass nil for the cookies parameter if you don't need cookie support:

```go
// Before
resp, err := client.Get(ctx, url, sessionID, proxyURL)

// After
resp, err := client.Get(ctx, url, sessionID, nil, proxyURL)
```